### PR TITLE
Ssl options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ But still it's pretty much fun to play with!
 
 ## Getting Started
 - Install [Node.js](https://nodejs.org/en/download/)
-- Install [yarn](https://yarnpkg.com/lang/en/docs/install)
+- Install [yarn](https://yarnpkg.com/lang/en/docs/install) or if you have npm just execute `npm install -g yarn`
 - Execute the following lines in your command line:
     ```
     $ yarn install

--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ But still it's pretty much fun to play with!
     $ yarn install
     $ yarn start --port 8081
     ```
-- Open https://localhost:8081/controller.html 
-- Open https://localhost:8081 in a second window
+- Open http://localhost:8081/controller.html 
+- Open http://localhost:8081 in a second window
 - Split the two windows left and right
 - Try some of the setups from presets (controller->lowerleft)
 - Play around
+
+More server options can be found [here](docs/server-options.md)
 
 ## Questions & Answers
 - Create an issue for your question

--- a/docs/server-options.md
+++ b/docs/server-options.md
@@ -1,0 +1,16 @@
+# Server options
+
+``--https`` Use this options to start server with ssl
+
+``--ssl-key path `` Use own private key for ssl
+
+``--ssl-certificate path`` Use own certificate for ssl
+
+
+## Examples
+
+### Start server with own ssl
+
+If you want to use indivisual over network, you can secure your connection with a command like this.
+
+``$ yarn start --https --ssl-key path_to_my_key.key --ssl-cert path_to_my_cert.crt``


### PR DESCRIPTION
Don't use https by default, because on a local machine that don't make sense. Also for a user, who try the software the first time, a ssl warning for a self sign certificate seem awkward for him i guess.

For more experienced users, they can now pass there own ssl cert and key or use the default one.

I also add a short hint for npm users to install yarn.